### PR TITLE
Use local gulp, add browser-sync dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@
 
   You also may need to install the `githug-pages` gem:
 
-      sudo gem install github-pages
+      gem install github-pages
 
   ## run & Build
 
   You'll need to build the JS and CSS:
 
-      gulp
+      npm run gulp
 
-  localhost:3000
+  Open `localhost:3000` in the browser.

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "uiuxconf",
   "version": "0.0.1",
   "description": "123",
+  "scripts": {
+    "gulp": "gulp"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/uiuxconf/uiuxconf-2016.git"
@@ -10,7 +13,6 @@
   "license": "WTFPL",
   "dependencies": {
     "bower": "*",
-    "gulp": "*",
     "gulp-concat": "*",
     "gulp-minify-css": "*",
     "gulp-sass": "*",
@@ -18,7 +20,8 @@
     "node-bourbon": "*"
   },
   "devDependencies": {
-    "gulp": "^3.9.1",
+    "gulp": "*",
+    "browser-sync": "*",
     "gulp-livereload": "^3.8.1"
   }
 }


### PR DESCRIPTION
Trying to build this to work out when the next jsconfcn will be.

I still end up getting this error on macOS Sierra:

```js
[15:58:02] 'jekyll-build' errored after 1.63 s
[15:58:02] Error: 1
    at formatError (/Users/gib/wrk/com/jsconf2017/node_modules/gulp/bin/gulp.js:169:10)
    at Gulp.<anonymous> (/Users/gib/wrk/com/jsconf2017/node_modules/gulp/bin/gulp.js:195:15)
    at emitOne (events.js:96:13)
    at Gulp.emit (events.js:188:7)
    at Gulp.Orchestrator._emitTaskDone (/Users/gib/wrk/com/jsconf2017/node_modules/orchestrator/index.js:264:8)
    at /Users/gib/wrk/com/jsconf2017/node_modules/orchestrator/index.js:275:23
    at finish (/Users/gib/wrk/com/jsconf2017/node_modules/orchestrator/lib/runTask.js:21:8)
    at ChildProcess.cb (/Users/gib/wrk/com/jsconf2017/node_modules/orchestrator/lib/runTask.js:29:3)
    at emitTwo (events.js:106:13)
    at ChildProcess.emit (events.js:191:7)
```